### PR TITLE
Enable contest's owner to view participants' code

### DIFF
--- a/ajax/contest_status_data.php
+++ b/ajax/contest_status_data.php
@@ -25,7 +25,7 @@ foreach ((array)contest_get_problem_basic($cid) as $row) {
     $ptol[$row["pid"]]=$row["lable"];
 }
 $ishide=contest_get_val($cid,"hide_others");
-if ($current_user->is_root()) $isroot=true;
+if ($current_user->is_root()||(contest_get_val($cid,"owner_viewable") && $current_user->match(contest_get_val($cid,"owner")))) $isroot=true;
 else $isroot=false;
 if ($ishide&&$isroot) $ishide=false;
 if (contest_passed($cid)) $hidedt=false;
@@ -117,7 +117,7 @@ foreach ( (array)$db->get_results( $sQuery,ARRAY_A ) as $aRow )
         if ($aRow["time_used"]!=0) $aRow["time_used"].=" ms"; else $aRow["time_used"]="";
     }
     $aRow["length(source)"].=" B";
-    if (!$current_user->match($aRow["username"])&&!$current_user->is_root()&&$hidedt) {
+    if (!$current_user->match($aRow["username"])&&!$isroot&&$hidedt) {
         $aRow["memory_used"]="";
         $aRow["time_used"]="";
         $aRow["length(source)"]="";

--- a/ajax/get_source.php
+++ b/ajax/get_source.php
@@ -17,7 +17,7 @@ if (!$current_user->is_valid()) {
     $ret["code"]=1;
     $ret["msg"]="Permission denined. Please login.";
 }
-else if (!(($ret["isshared"]==TRUE&&($cid=="0"||contest_passed($cid)))||$current_user->match($uname)||$current_user->is_codeviewer())) {
+else if (!(($ret["isshared"]==TRUE&&($cid=="0"||contest_passed($cid)))||$current_user->match($uname)||$current_user->is_codeviewer()||(contest_get_val($cid,"owner_viewable") && $current_user->match(contest_get_val($cid,"owner"))))) {
     unset($ret);
     $ret["code"]=1;
     $ret["msg"]="Permission denined.";

--- a/ajax/vcontest_arrange.php
+++ b/ajax/vcontest_arrange.php
@@ -27,6 +27,7 @@ if ($current_user->is_valid()) {
 
     $ctype=convert_str($_POST['ctype']);
     $hide_others=convert_str($_POST['hide_others']);
+    $owner_viewable=$_POST['owner_viewable']=="on"?1:0;
     $pass=pwd(convert_str($_POST['password']));
     if ($_POST['password']!="") $isprivate=2;
     if ($ctype==0) $n = $config["limits"]["problems_on_contest_add"];
@@ -67,8 +68,8 @@ if ($current_user->is_valid()) {
     }
     else {
     
-        $sql_add_con = "insert into contest (title,description,isprivate,lock_board_time,start_time,end_time,hide_others,owner,isvirtual,type,password) values ('$title'" .
-                ",'$description','$isprivate','$lock_board_time','$start_time','$end_time','$hide_others','$nowuser',1,'$ctype','$pass')";
+        $sql_add_con = "insert into contest (title,description,isprivate,lock_board_time,start_time,end_time,hide_others,owner,isvirtual,type,password,owner_viewable) values ('$title'" .
+                ",'$description','$isprivate','$lock_board_time','$start_time','$end_time','$hide_others','$nowuser',1,'$ctype','$pass','$owner_viewable')";
         //$sql_add_con = change_in($sql_add_con);
         //echo "<br/>".$sql_add_con."<br/>";
         $pd=false;

--- a/ajax/vcontest_modify.php
+++ b/ajax/vcontest_modify.php
@@ -27,6 +27,7 @@ if (contest_exist($cid)&&!contest_passed($cid)&&($current_user->is_root()||$curr
 
     $ctype=convert_str($_POST['ctype']);
     $hide_others=convert_str($_POST['hide_others']);
+    if(!contest_started($cid)) $owner_viewable=$_POST['owner_viewable']=="on"?1:0;
     $pass=pwd(convert_str($_POST['password']));
     if ($_POST['password']!="") $isprivate=2;
     if ($ctype==0) $n = $config["limits"]["problems_on_contest_add"];
@@ -75,7 +76,8 @@ if (contest_exist($cid)&&!contest_passed($cid)&&($current_user->is_root()||$curr
             end_time='$end_time',
             hide_others='$hide_others',
             type='$ctype',
-            password='$pass'
+            password='$pass',
+            owner_viewable='$owner_viewable'
             where cid='$cid'";
         else $sql_add_con = "update contest set
             title='$title',
@@ -84,7 +86,6 @@ if (contest_exist($cid)&&!contest_passed($cid)&&($current_user->is_root()||$curr
             where cid='$cid'";
 
         //$sql_add_con = change_in($sql_add_con);
-        //echo "<br/>".$sql_add_con."<br/>";
         if (!contest_started($cid)) {
             $pd=false;
             for($i=0;$i<$n;$i++){

--- a/contest.php
+++ b/contest.php
@@ -77,6 +77,7 @@ include_once("functions/contests.php");
                             <tr><td><label class="radio inline"><input type="radio" name="hide_others" value="1" /> Hide others' status</label><label class="radio inline"><input type="radio" name="hide_others" value="0" checked="checked" />  Show others' status</label></td></tr>
                             <tr><td><div class="input-prepend"><span class="add-on">Password: </span><input type="password" name="password" /></div></td></tr>
                             <tr><td>( Leave it blank if not needed )</td></tr>
+                            <tr><td><input type="checkbox" name="owner_viewable" />Allow owner view participant's code</td></tr>
                         </table>
                     </div>
 

--- a/contest_edit.php
+++ b/contest_edit.php
@@ -48,6 +48,13 @@ if (!contest_started($cid)) {
 ?>
                         <tr><td><div class="input-prepend"><span class="add-on">Password: </span><input type="password" name="password" /></div></td></tr>
                         <tr><td>( Leave it blank if not needed )</td></tr>
+<?php
+if (!contest_started($cid)) {
+?>
+    <tr><td><input type="checkbox" name="owner_viewable" <?=contest_get_val($cid,"owner_viewable")==1?'checked="checked"':''?>/>Allow owner view participant's code</td></tr>
+<?
+}
+?>
                     </table>
                 </div>
 

--- a/contest_prob.php
+++ b/contest_prob.php
@@ -233,6 +233,15 @@ if (!contest_started($cid)||!($current_user->is_root()||contest_get_val($cid,"is
             <tr>
               <td colspan="2"><textarea rows="12" class="input-block-level" name="source" onKeyUp="if(this.value.length > <?=$config["limits"]["max_source_code_len"]?>) this.value=this.value.substr(0,<?=$config["limits"]["max_source_code_len"]?>)" placeholder="Put your solution here..."></textarea></td>
             </tr>
+<?php
+if(contest_get_val($cid,"owner_viewable")){
+?>
+            <tr>
+              <td colspan="2">The owner of the contest <b>WILL BE ABLE</b> to see your code.</td>
+            </tr>
+<?php
+}
+?>
           </table>
         </div>
         <div class="modal-footer">

--- a/contest_status.php
+++ b/contest_status.php
@@ -68,7 +68,7 @@ if (contest_get_val($cid,"has_cha")) {
             </form>
           </div>
 <?php
-if (contest_get_val($cid,"hide_others")&&!$current_user->is_root()) {
+if (contest_get_val($cid,"hide_others")&&!$current_user->is_root()&&!(contest_get_val($cid,"owner_viewable") && $current_user->match(contest_get_val($cid,"owner")))) {
 ?>
         <div class="tcenter"><b>In this contest, you can only view the submits from yourself.</b></div>
 <?php


### PR DESCRIPTION
A new option is provided in the arrange/modify vcontest page to enable contest's owner to view participants code. When turned on, prompting text will be shown in the submit page.

DATABASE CHANGE: owner_viewable tinyint(1) is added to table contest.
