### PR TITLE
codechef crawler fails to deal with non-exist problem and mess up the pa...

### DIFF
--- a/functions/pcrawlers.php
+++ b/functions/pcrawlers.php
@@ -1379,8 +1379,8 @@ function pcrawler_codechef($pid) {
     $url="http://www.codechef.com/problems/$pid";
     $content=file_get_contents($url);
     $ret=array();
-    if (stripos($content,"We don't have problems of this category :)</div>")===false) {
-        if (preg_match('/<h1>(.*)<\/h1>/sU', $content,$matches)) $ret["title"]=trim($matches[1]);
+    if (stripos($content,"CodeChef</title>")!==false) {
+        if (preg_match('/<h1>(.*)</sU', $content,$matches)) $ret["title"]=trim($matches[1]);
         if (preg_match('/Time Limit:<\/td>\s*<td>(.*) sec/sU', $content,$matches)) $ret["case_time_limit"]=$ret["time_limit"]=intval(trim($matches[1]))*1000;
         $ret["memory_limit"]="0";
         if (preg_match('/<div class="meta">.*<div class="content">(.*)<\/div>.*<hr \/>/sU', $content,$matches)) $ret["description"]=trim($matches[1]);


### PR DESCRIPTION
...ge

It seems the prompt text is dynamically loading, so title is used instead to determine whether the problem exists.

And regex for fetching problem title is updated.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bnuacm/bnuoj-web-v3/17)

<!-- Reviewable:end -->
