### PR TITLE
Improve sample input/output display

### DIFF
--- a/problem_show.php
+++ b/problem_show.php
@@ -142,7 +142,7 @@ if (!$show_problem->is_valid()||($show_problem->get_val("hide")==1&&!$current_us
 ?>
             <h3> Sample Input </h3>
 <?php
-    if (stristr($sin,'<br')==null&&stristr($sin,'<pre')==null&&stristr($sin,'<p>')==null) {
+    if (stristr($sin,'<br')==null&&stristr($sin,'<pre')==null&&stristr($sin,'<p')==null) {
 ?>
             <pre class="content-wrapper"><?=$sin?></pre>
 <?php


### PR DESCRIPTION
i think <p will be better than <p>, and it solve the little LightOJ problem where linebreaks in table are maintained due to the <pre> wrapper

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bnuacm/bnuoj-web-v3/21)

<!-- Reviewable:end -->
