### PR TITLE
Deprecate adjlist.js and move oj language info into database

### DIFF
--- a/ajax/contest_problem_submit.php
+++ b/ajax/contest_problem_submit.php
@@ -70,6 +70,12 @@ if ($lang==0) {
     echo json_encode($ret);
     die();
 }
+list($vname)=@$db->get_row("select vname from problem where pid='$pid'",ARRAY_N);
+if (!in_array($lang,problem_support_lang($vname))){
+    $ret["msg"]="Language Invalid.";
+    echo json_encode($ret);
+    die();
+}
 if (time()-strtotime($current_user->get_val("last_submit_time"))<5) {
     $ret["msg"]="Too Fast!";
     echo json_encode($ret);
@@ -103,7 +109,6 @@ else {
     if (contest_get_val($cid,"has_cha")=="1") $msg=$config["contact"]["pretest"]."\n".$nowid;
     else $msg=$config["contact"]["submit"]."\n".$nowid;
 
-    list($vname)=@$db->get_row("select vname from problem where pid='$pid'",ARRAY_N);
     $msg=$msg."\n".$vname;
     if (@fwrite($fp,$msg)===FALSE) {
         if ($cid=="0") $ret["msg"]="Transmitted.";

--- a/ajax/problem_submit.php
+++ b/ajax/problem_submit.php
@@ -43,7 +43,12 @@ if ($lang==0) {
     echo json_encode($ret);
     die();
 }
-
+list($vname)=@$db->get_row("select vname from problem where pid='$pid'",ARRAY_N);
+if (!in_array($lang,problem_support_lang($vname))){
+    $ret["msg"]="Language Invalid.";
+    echo json_encode($ret);
+    die();
+}
 if (time()-strtotime($current_user->get_val("last_submit_time"))<5) {
     $ret["msg"]="Too Fast!";
     echo json_encode($ret);
@@ -73,7 +78,6 @@ if (!$fp) {
 }
 else {
     $msg=$config["contact"]["submit"]."\n".$nowid;
-    list($vname)=@$db->get_row("select vname from problem where pid='$pid'",ARRAY_N);
     $msg=$msg."\n".$vname;
     if (@fwrite($fp,$msg)===FALSE) {
         $ret["msg"]="Submitted.";

--- a/contest_prob.php
+++ b/contest_prob.php
@@ -256,3 +256,7 @@ if(contest_get_val($cid,"owner_viewable")){
 <?php
 }
 ?>
+
+<script type="text/javascript">
+var support_lang=<?= json_encode($show_problem->get_val("support_lang")) ?>;
+</script>

--- a/contest_show.php
+++ b/contest_show.php
@@ -158,7 +158,6 @@ var lim_times=<?=$config["status"]["max_refresh_times"]?>;
 </script>
 <link href="css/prettify.css" type="text/css" rel="stylesheet" />
 <script type="text/javascript" src="js/prettify.js"></script>
-<script type="text/javascript" src="js/adjlist.js?<?=filemtime("js/adjlist.js")?>" ></script>
 <script type="text/javascript" src="js/animator.js"></script>
 <script type="text/javascript" src="js/rankingTableUpdate.js"></script>
 <script type="text/javascript" src="js/contest_show.js?<?= filemtime("js/contest_show.js") ?>"></script>

--- a/functions/sidebars.php
+++ b/functions/sidebars.php
@@ -193,7 +193,7 @@ function sidebar_item_content_user_stat($user) {
 
 function sidebar_item_content_problem_stat($problem) {
     if (!$problem->is_valid()) return "";
-    $stat=$problem->get_stat();
+    $stat=$problem->get_val("stat");
     $pid=$problem->get_val("pid");
     $value=sidebar_item_top()."            <div id='probpie' class='highcharts-container'>
             </div>

--- a/js/contest_show.js
+++ b/js/contest_show.js
@@ -23,7 +23,9 @@ var showpfunc=function(gcpid) {
         $("#submitdialog").on("shown",function() {
             $("#submitdialog textarea").focus();
         });
-        adjustlist("",$("#submitdialog").attr("name"));
+        $("#lang option").each(function(){
+          if( $.inArray($(this).val(), support_lang)==-1 ) $(this).remove();
+        });
         if ($.cookie(cookie_prefix+"defaultshare")=="0") $("input[name='isshare']:nth(1)").attr("checked",true);
         else $("input[name='isshare']:nth(0)").attr("checked",true);
 

--- a/js/problem_show.js
+++ b/js/problem_show.js
@@ -1,6 +1,5 @@
 $(document).ready(function() {
     $("#problem").addClass("active");
-    adjustlist(pvid,pvname);
     $(".submitprob").click(function() {
         if ($.cookie(cookie_prefix+"username")==null) $("#logindialog").modal("show");
         else $("#submitdialog").modal("show");
@@ -43,4 +42,8 @@ $(document).ready(function() {
     });
 
     $("#utags").select2();
+
+    $("#lang option").each(function(){
+        if( $.inArray($(this).val(), support_lang)==-1 ) $(this).remove();
+    });
 });

--- a/problem_show.php
+++ b/problem_show.php
@@ -186,7 +186,7 @@ if (!$show_problem->is_valid()||($show_problem->get_val("hide")==1&&!$current_us
             </div>
 <?php
   }
-  $p_cat=$show_problem->get_tagged_category();
+  $p_cat=$show_problem->get_val("tagged_category");
   if (sizeof($p_cat)>0) {
 ?>
             <h3> Tags <button class="btn btn-danger" id="ptags">Toggle</button> </h3>
@@ -295,11 +295,11 @@ if (!$show_problem->is_valid()||($show_problem->get_val("hide")==1&&!$current_us
       </form>
     </div>
 
-<script type="text/javascript" src="js/adjlist.js?<?=filemtime("js/adjlist.js") ?>" ></script>
 <script type="text/javascript">
 var ppid='<?= $pid ?>';
 var pvid="<?= $show_problem->get_val("vid") ?>";
 var pvname="<?= $show_problem->get_val("vname") ?>";
+var support_lang=<?= json_encode($show_problem->get_val("support_lang")) ?>;
 </script>
 <script type="text/javascript" src="js/problem_show.js?<?= filemtime("js/problem_show.js") ?>"></script>
 <?php


### PR DESCRIPTION
It's stored in `supportlang` column in `ojinfo` as a comma-separated list.

I also modifed problem class, turning getters into private functions, leaving get_val() as the only entrance to avoid duplicate checkings.

I wonder if it's necessary to check language validness when submitting, since a normal submit should never contain wrong lang id, and wrong lang id won't do any harm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bnuacm/bnuoj-web-v3/22)

<!-- Reviewable:end -->
